### PR TITLE
add logger. log load_labs function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Depends:
   ggplot2
 Imports:
   curl,
-  rstudioapi
+  rstudioapi,
+  log4r
 Suggests:
   testthat
 License: GPL (>= 2)

--- a/R/load_lab.R
+++ b/R/load_lab.R
@@ -88,10 +88,17 @@ load_labs <- function(lab) {
                      .format_lab_title(lab_titles), '.html')
   if (is.null(lab)) {
     selection <- menu(lab_titles, title = "Enter the number next to the lab you would like to load:")
+    .log_loaded_lab(selection)
     url <- lab_urls[selection]
   }
   if (!is.null(lab)) {
+    .log_loaded_lab(lab)
     url <- lab_urls[lab]
   }
   return(url)
+}
+
+.log_loaded_lab <- function (lab) {
+  # logs the load_lab command correctly regardless of how the user selected a lab
+  log_info(paste('load_lab(',lab,')', sep = ""))
 }

--- a/R/logger.R
+++ b/R/logger.R
@@ -1,0 +1,31 @@
+log_config <- log4r::create.logger()
+
+.onLoad <- function(libname, pkgname) {
+  log_path <- Sys.getenv('MOBILIZR_LOGFILE', '~/.mobilizr.log')
+  logger_set(file.path(log_path), "INFO")
+}
+
+logger_set <- function(logfile = NULL, level = NULL){
+  log4r::logfile(log_config) <<- logfile
+  log4r::level(log_config) <<- level
+}
+
+log_debug <- function(msg){
+  log4r::debug(log_config, msg)
+}
+
+log_info <- function(msg){
+  log4r::info(log_config, msg)
+}
+
+log_warn <- function(msg){
+  log4r::warn(log_config, msg)
+}
+
+log_error <- function(msg){
+  log4r::error(log_config, msg)
+}
+
+log_fatal <- function(msg){
+  log4r::fatal(log_config, msg)
+}


### PR DESCRIPTION
@jimmylovestea @hongsudt 
- Add support for logging arbitrary items to the user's home directory.
- by default logs to `~/.mobilizr.log`, can be set to an alternate location by passing `MOBILIZR_LOGFILE` environment varaible.

We start out by correctly logging the lab loaded from `load_lab()` regardless of whether the user passed the lab as a param or used the menu to select.

(also thanks to @jeroenooms for help in teaching me some R coding basics :+1: )
